### PR TITLE
Adds export LANG=C to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # expand image to whole sd-card
+export LANG=C
 sudo raspi-config --expand-rootfs
 
 # Disable boot straight to desktop


### PR DESCRIPTION
sd card image resizing stopped working on the latest raspbian
image, as locales were removed, setting it explicitly to C before
calling the resize command fixes this
