### PR TITLE
Adds daily cron autoupdater script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,13 @@ sync
 
 sudo apt-get autoremove -y
 sudo apt-get autoclean -y
+
+sudo cp -f /home/pi/extremefeedbacklamp/xfdlampupdate.sh /etc/cron.daily/xfdlampupdate
+sudo chmod +x /etc/cron.daily/xfdlampupdate
+# if daily updates just ain't quick enough
+#sudo cp -f /home/pi/extremefeedbacklamp/xfdlampupdate.sh /etc/cron.hourly/xfdlampupdate
+#sudo chmod +x /etc/cron.hourly/xfdlampupdate
+
 sync
 
 # reboot

--- a/xfdlampupdate.sh
+++ b/xfdlampupdate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+cd /home/pi/extremefeedbacklamp
+git fetch
+DELTAPRE=$(git rev-list HEAD...origin/master --count)
+git reset --hard origin/master
+DELTAPOST=$(git rev-list HEAD...origin/master --count)
+if [ "$DELTAPRE" != "$DELTAPOST" ]
+then
+    echo "update found and applied succesfully, rebooting"
+    sudo cp -f /home/pi/extremefeedbacklamp/xfdlampupdate.sh /etc/cron.daily/xfdlampupdate
+    sudo chmod +x /etc/cron.daily/xfdlampupdate
+    #sudo cp -f /home/pi/extremefeedbacklamp/xfdlampupdate.sh /etc/cron.hourly/xfdlampupdate
+    #sudo chmod +x /etc/cron.hourly/xfdlampupdate
+    sudo shutdown -r now
+fi


### PR DESCRIPTION
Script to do daily automatic updates of the lamp software
installs script as part of install.sh, also copies itself to
/etc/cron.daily at each run.
Reboots the lamp if updates applied successfully.

Note that changes to cronupdate.sh are not executed till the next
days cron update run.
